### PR TITLE
feat(types): dropin/headless doc sync for June '26

### DIFF
--- a/src/generated/types/dropin.d.ts
+++ b/src/generated/types/dropin.d.ts
@@ -150,6 +150,7 @@ export type IntegratedToken = {
 	name?: string;
 	source?: "MERCHANT" | "SHARED_WALLET";
 	savable_to_shared_wallet?: boolean;
+	created_at?: string;
 };
 export interface MethodConfiguration {
 	stable: boolean;
@@ -553,6 +554,9 @@ export interface WalletAPI {
 		reason?: string;
 	}): Promise<void>;
 	deleteAllTokens(): Promise<void>;
+	setAsFavorite(data: {
+		id: string;
+	}): Promise<void>;
 }
 export interface MonitoringAPI<E> {
 	getApiKey(): string;
@@ -1644,7 +1648,7 @@ export declare interface Payment {
 	paymentSession: Readable<PaymentSession | null>;
 	session: PaymentSession;
 	walletSession: WalletSession | null;
-	setSession(session: OrchestrationPaymentSession | LegacyPaymentSession): Promise<void>;
+	setSession(session: LegacyPaymentSession): Promise<void>;
 	onExpires(callback: () => void): () => void;
 	getMop(mop: Partial<PurseHeadlessCheckoutPaymentItemBase>): PurseHeadlessCheckoutPaymentItem | null;
 	deleteAllTokens(): Promise<void>;
@@ -1697,7 +1701,8 @@ export declare interface PaymentElementEventsPayload {
 export declare type PaymentElementOptions = Omit<Options, "hostedFields">;
 export declare interface PaymentSession {
 	id: string;
-	source: OrchestrationPaymentSession | LegacyPaymentSession;
+	source: LegacyPaymentSession;
+	rawSource?: OrchestrationPaymentSession;
 	amount: number;
 	amountCts: number;
 	isInformationRequest: boolean;
@@ -2149,6 +2154,11 @@ declare const PurseHeadlessCheckoutErrors: {
 		readonly message: "Method not found.";
 		readonly documentationLink: "https://docs.purse.tech/docs/integrate/purse-checkout/headless-checkout/error-handling/error-codes#payment_method_not_found";
 	};
+	readonly METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS: {
+		readonly code: "METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS";
+		readonly message: "The resolved payment method does not support hosted fields.";
+		readonly documentationLink: "https://docs.purse.tech/docs/integrate/purse-checkout/headless-checkout/error-handling/error-codes#method_does_not_support_hosted_fields";
+	};
 	readonly UNKNOWN_ERROR: {
 		readonly code: "UNKNOWN_ERROR";
 		readonly message: "An error occurred.";
@@ -2367,6 +2377,10 @@ export declare interface PurseHeadlessCheckoutErrorsPayload {
 		partner: Partner;
 		method: Method;
 		session: string;
+	};
+	METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS?: {
+		partner: string;
+		method: string;
 	};
 	UNKNOWN_ERROR?: {
 		message: string;
@@ -2612,15 +2626,18 @@ export declare interface PurseHeadlessCheckoutEventPayload {
  *
  * - `hostedForm` and `hostedFields` are mutually exclusive. If both are provided,
  *   `hostedForm` wins and a warning is emitted.
- * - `method` is required for `hostedForm`; it is optional when only `hostedFields`
- *   is provided (the first compatible method on `partner` is picked).
- * - A warning is emitted when `hostedFields` is requested but the resolved method
- *   does not support hosted fields.
+ * - `partner` is optional. When omitted, the first primary matching `method` is used.
+ *   If multiple partners expose the same method a warning is emitted — pass `partner`
+ *   to disambiguate.
+ * - `method` is optional when only `hostedFields` is provided (the first hosted-fields-
+ *   compatible method is picked; falls back to the first available primary).
+ * - Throws `METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS` when the resolved method does not
+ *   support hosted fields.
  * - Throws `PAYMENT_METHOD_NOT_FOUND` if no matching method exists.
  */
 export declare interface PurseHeadlessCheckoutGetPaymentElementOptions {
-	/** Partner identifier (e.g. `'ingenico'`, `'hipay'`). */
-	partner: string;
+	/** Partner identifier (e.g. `'ingenico'`, `'hipay'`). Optional — omit to match by method alone. */
+	partner?: string;
 	/** Method identifier (e.g. `'creditcard'`). Optional only when using `hostedFields`. */
 	method?: string;
 	/** Theme overrides — passed through as-is to the underlying element. */
@@ -2631,6 +2648,8 @@ export declare interface PurseHeadlessCheckoutGetPaymentElementOptions {
 	hostedForm?: HostedFormUIOptions;
 	/** Hosted fields configuration — see {@link HostedFieldsUIOptions.fields}. */
 	hostedFields?: HostedFieldsUIOptions["fields"];
+	/** xPay button configuration (Apple Pay, Google Pay) — see {@link XPayButtonUIOptions}. */
+	xPayButton?: XPayButtonUIOptions;
 }
 export declare interface PurseHeadlessCheckoutHooks {
 	/**
@@ -2927,6 +2946,8 @@ export declare interface PurseHeadlessCheckoutPrimaryMethod extends PurseHeadles
 	isSecondary: false;
 	/** Whether the method can provide loan simulation or not*/
 	simulable: boolean;
+	/** Whether the method supports hosted fields (secure card input via iframes) */
+	supportsHostedFields: boolean;
 	/**
 	 * Creates and returns a payment element UI instance for this payment method.
 	 * The instance is created only on the first call and cached for subsequent calls.
@@ -3030,6 +3051,8 @@ export declare interface PurseHeadlessCheckoutPrimaryToken extends PurseHeadless
 	type: "token";
 	/** Indicates if the token is a secondary mean of payment */
 	isSecondary: false;
+	/** Whether the token supports hosted fields (secure card input via iframes) */
+	supportsHostedFields: boolean;
 	/**
 	 * Description holds all display values to describe the token in a UI. This is useful since the rendering of a token
 	 * is limited to the CVV.
@@ -3117,6 +3140,22 @@ export declare interface PurseHeadlessCheckoutPrimaryToken extends PurseHeadless
 	 * ```
 	 */
 	setAsPrimarySource(): void;
+	/** Whether this token is the user's favorite payment method. Reflects `IntegratedToken.favorite`. */
+	isFavorite: Readable<boolean>;
+	/**
+	 * Mark this token as the user's favorite. Persists the change via the wallet API.
+	 *
+	 * @throws - {@link PurseHeadlessCheckoutError} `MISSING_WALLET_SESSION` \
+	 * If no wallet session is loaded
+	 * @throws - {@link PurseHeadlessCheckoutError} `MISSING_TOKEN` \
+	 * If the token is not found in the wallet
+	 *
+	 * @example
+	 * ```typescript
+	 * await token.setAsFavorite();
+	 * ```
+	 */
+	setAsFavorite(): Promise<void>;
 }
 export declare interface PurseHeadlessCheckoutRegisterable {
 	/**
@@ -3300,6 +3339,11 @@ export declare interface PurseHeadlessCheckoutToken extends PurseHeadlessCheckou
 	name: string;
 	type: "token" | "temporary_token";
 	/**
+	 * ISO 8601 date string indicating when the token was created.
+	 * Useful for sorting saved payment methods chronologically.
+	 */
+	createdAt?: string;
+	/**
 	 * Indicates if the payment token is disabled with an error code and message
 	 */
 	disabled: Readable<DisabledState | null>;
@@ -3358,7 +3402,7 @@ declare class PursePayment implements Payment {
 	});
 	get session(): PaymentSession;
 	get walletSession(): WalletSession | null;
-	setSession(session: OrchestrationPaymentSession | LegacyPaymentSession): Promise<void>;
+	setSession(session: LegacyPaymentSession): Promise<void>;
 	setWalletSession(session: OnePayWalletSession): Promise<void>;
 	onExpires(callback: () => void): () => void;
 	getMop(mop: Partial<PurseHeadlessCheckoutPaymentItem>): PurseHeadlessCheckoutPaymentItem | null;
@@ -3494,6 +3538,7 @@ declare const DropinThemeSchema: z.ZodObject<{
 		fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined;
 	}>>;
 	title: z.ZodOptional<z.ZodObject<{
+		color: z.ZodOptional<z.ZodString>;
 		fontSize: z.ZodOptional<z.ZodString>;
 		fontWeight: z.ZodOptional<z.ZodEnum<[
 			"normal",
@@ -3513,9 +3558,49 @@ declare const DropinThemeSchema: z.ZodObject<{
 	}, "strict", z.ZodTypeAny, {
 		fontSize?: string | undefined;
 		fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined;
+		color?: string | undefined;
 	}, {
 		fontSize?: string | undefined;
 		fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined;
+		color?: string | undefined;
+	}>>;
+	xpay: z.ZodOptional<z.ZodObject<{
+		apple: z.ZodOptional<z.ZodObject<{
+			buttonstyle: z.ZodOptional<z.ZodEnum<[
+				"black",
+				"white",
+				"white-outline"
+			]>>;
+		}, "strict", z.ZodTypeAny, {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		}, {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		}>>;
+		google: z.ZodOptional<z.ZodObject<{
+			buttonColor: z.ZodOptional<z.ZodEnum<[
+				"black",
+				"white",
+				"default"
+			]>>;
+		}, "strict", z.ZodTypeAny, {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		}, {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		}>>;
+	}, "strict", z.ZodTypeAny, {
+		apple?: {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		} | undefined;
+		google?: {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		} | undefined;
+	}, {
+		apple?: {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		} | undefined;
+		google?: {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		} | undefined;
 	}>>;
 }, "strict", z.ZodTypeAny, {
 	fontFamily?: "Roboto" | "Montserrat" | "Raleway" | "Inter" | "Noto Sans" | "Open Sans" | "Lato" | "Nunito" | "Work Sans" | undefined;
@@ -3530,6 +3615,15 @@ declare const DropinThemeSchema: z.ZodObject<{
 	title?: {
 		fontSize?: string | undefined;
 		fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined;
+		color?: string | undefined;
+	} | undefined;
+	xpay?: {
+		apple?: {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		} | undefined;
+		google?: {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		} | undefined;
 	} | undefined;
 }, {
 	fontFamily?: "Roboto" | "Montserrat" | "Raleway" | "Inter" | "Noto Sans" | "Open Sans" | "Lato" | "Nunito" | "Work Sans" | undefined;
@@ -3544,6 +3638,15 @@ declare const DropinThemeSchema: z.ZodObject<{
 	title?: {
 		fontSize?: string | undefined;
 		fontWeight?: "normal" | "bold" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined;
+		color?: string | undefined;
+	} | undefined;
+	xpay?: {
+		apple?: {
+			buttonstyle?: "black" | "white" | "white-outline" | undefined;
+		} | undefined;
+		google?: {
+			buttonColor?: "black" | "white" | "default" | undefined;
+		} | undefined;
 	} | undefined;
 }>;
 export type DropinTheme = z.infer<typeof DropinThemeSchema>;
@@ -3931,9 +4034,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -4139,9 +4245,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -4347,9 +4456,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -4576,9 +4688,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -4805,9 +4920,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -5034,9 +5152,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -5263,9 +5384,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -5492,9 +5616,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -5721,9 +5848,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -5950,9 +6080,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -6179,9 +6312,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -6408,9 +6544,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -6637,9 +6776,12 @@ declare const translationFiles: {
 			common: {
 				submittingPayment: string;
 				sessionExpired: string;
+				sessionExpiredTitle: string;
+				sessionExpiredBody: string;
 				sessionTerminated: string;
 				today: string;
 				refreshSession: string;
+				refreshPageToTryAgain: string;
 				refreshSessionError: string;
 			};
 			giftCards: {
@@ -6746,7 +6888,7 @@ export type InitOptions = {
 	locale?: keyof typeof translationFiles;
 	hidePayButton?: boolean;
 	hooks?: {
-		onRefreshSession?: () => void | Promise<void>;
+		onRefreshSession?: () => PurseHeadlessCheckoutV1Params["paymentSession"] | string | void | Promise<PurseHeadlessCheckoutV1Params["paymentSession"] | string | void>;
 	};
 };
 declare class PurseDropin {

--- a/src/generated/types/headless-checkout.d.ts
+++ b/src/generated/types/headless-checkout.d.ts
@@ -255,6 +255,7 @@ export type IntegratedToken = {
 	name?: string;
 	source?: "MERCHANT" | "SHARED_WALLET";
 	savable_to_shared_wallet?: boolean;
+	created_at?: string;
 };
 export interface MethodConfiguration {
 	stable: boolean;
@@ -658,6 +659,9 @@ export interface WalletAPI {
 		reason?: string;
 	}): Promise<void>;
 	deleteAllTokens(): Promise<void>;
+	setAsFavorite(data: {
+		id: string;
+	}): Promise<void>;
 }
 export interface MonitoringAPI<E> {
 	getApiKey(): string;
@@ -1861,6 +1865,11 @@ declare const PurseHeadlessCheckoutErrors: {
 		readonly message: "Method not found.";
 		readonly documentationLink: "https://docs.purse.tech/docs/integrate/purse-checkout/headless-checkout/error-handling/error-codes#payment_method_not_found";
 	};
+	readonly METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS: {
+		readonly code: "METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS";
+		readonly message: "The resolved payment method does not support hosted fields.";
+		readonly documentationLink: "https://docs.purse.tech/docs/integrate/purse-checkout/headless-checkout/error-handling/error-codes#method_does_not_support_hosted_fields";
+	};
 	readonly UNKNOWN_ERROR: {
 		readonly code: "UNKNOWN_ERROR";
 		readonly message: "An error occurred.";
@@ -2080,6 +2089,10 @@ export interface PurseHeadlessCheckoutErrorsPayload {
 		partner: Partner;
 		method: Method;
 		session: string;
+	};
+	METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS?: {
+		partner: string;
+		method: string;
 	};
 	UNKNOWN_ERROR?: {
 		message: string;
@@ -2359,6 +2372,11 @@ export interface PurseHeadlessCheckoutToken extends PurseHeadlessCheckoutPayment
 	name: string;
 	type: "token" | "temporary_token";
 	/**
+	 * ISO 8601 date string indicating when the token was created.
+	 * Useful for sorting saved payment methods chronologically.
+	 */
+	createdAt?: string;
+	/**
 	 * Indicates if the payment token is disabled with an error code and message
 	 */
 	disabled: Readable<DisabledState | null>;
@@ -2387,15 +2405,18 @@ export type PaymentElementOptions = Omit<Options, "hostedFields">;
  *
  * - `hostedForm` and `hostedFields` are mutually exclusive. If both are provided,
  *   `hostedForm` wins and a warning is emitted.
- * - `method` is required for `hostedForm`; it is optional when only `hostedFields`
- *   is provided (the first compatible method on `partner` is picked).
- * - A warning is emitted when `hostedFields` is requested but the resolved method
- *   does not support hosted fields.
+ * - `partner` is optional. When omitted, the first primary matching `method` is used.
+ *   If multiple partners expose the same method a warning is emitted — pass `partner`
+ *   to disambiguate.
+ * - `method` is optional when only `hostedFields` is provided (the first hosted-fields-
+ *   compatible method is picked; falls back to the first available primary).
+ * - Throws `METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS` when the resolved method does not
+ *   support hosted fields.
  * - Throws `PAYMENT_METHOD_NOT_FOUND` if no matching method exists.
  */
 export interface PurseHeadlessCheckoutGetPaymentElementOptions {
-	/** Partner identifier (e.g. `'ingenico'`, `'hipay'`). */
-	partner: string;
+	/** Partner identifier (e.g. `'ingenico'`, `'hipay'`). Optional — omit to match by method alone. */
+	partner?: string;
 	/** Method identifier (e.g. `'creditcard'`). Optional only when using `hostedFields`. */
 	method?: string;
 	/** Theme overrides — passed through as-is to the underlying element. */
@@ -2406,6 +2427,8 @@ export interface PurseHeadlessCheckoutGetPaymentElementOptions {
 	hostedForm?: HostedFormUIOptions;
 	/** Hosted fields configuration — see {@link HostedFieldsUIOptions.fields}. */
 	hostedFields?: HostedFieldsUIOptions["fields"];
+	/** xPay button configuration (Apple Pay, Google Pay) — see {@link XPayButtonUIOptions}. */
+	xPayButton?: XPayButtonUIOptions;
 }
 /**
  * Represents a primary payment method in the Purse checkout system.
@@ -2431,6 +2454,8 @@ export interface PurseHeadlessCheckoutPrimaryMethod extends PurseHeadlessCheckou
 	isSecondary: false;
 	/** Whether the method can provide loan simulation or not*/
 	simulable: boolean;
+	/** Whether the method supports hosted fields (secure card input via iframes) */
+	supportsHostedFields: boolean;
 	/**
 	 * Creates and returns a payment element UI instance for this payment method.
 	 * The instance is created only on the first call and cached for subsequent calls.
@@ -2551,6 +2576,8 @@ export interface PurseHeadlessCheckoutPrimaryToken extends PurseHeadlessCheckout
 	type: "token";
 	/** Indicates if the token is a secondary mean of payment */
 	isSecondary: false;
+	/** Whether the token supports hosted fields (secure card input via iframes) */
+	supportsHostedFields: boolean;
 	/**
 	 * Description holds all display values to describe the token in a UI. This is useful since the rendering of a token
 	 * is limited to the CVV.
@@ -2638,6 +2665,22 @@ export interface PurseHeadlessCheckoutPrimaryToken extends PurseHeadlessCheckout
 	 * ```
 	 */
 	setAsPrimarySource(): void;
+	/** Whether this token is the user's favorite payment method. Reflects `IntegratedToken.favorite`. */
+	isFavorite: Readable<boolean>;
+	/**
+	 * Mark this token as the user's favorite. Persists the change via the wallet API.
+	 *
+	 * @throws - {@link PurseHeadlessCheckoutError} `MISSING_WALLET_SESSION` \
+	 * If no wallet session is loaded
+	 * @throws - {@link PurseHeadlessCheckoutError} `MISSING_TOKEN` \
+	 * If the token is not found in the wallet
+	 *
+	 * @example
+	 * ```typescript
+	 * await token.setAsFavorite();
+	 * ```
+	 */
+	setAsFavorite(): Promise<void>;
 	/**
 	 * @internal
 	 * this is useful for completing the payment
@@ -3166,7 +3209,8 @@ declare class ApiLogger extends FetchMonitoringAPI<PurseHeadlessCheckoutEventBus
 }
 export interface PaymentSession {
 	id: string;
-	source: OrchestrationPaymentSession | LegacyPaymentSession;
+	source: LegacyPaymentSession;
+	rawSource?: OrchestrationPaymentSession;
 	amount: number;
 	amountCts: number;
 	isInformationRequest: boolean;
@@ -3207,7 +3251,7 @@ export interface Payment {
 	paymentSession: Readable<PaymentSession | null>;
 	session: PaymentSession;
 	walletSession: WalletSession | null;
-	setSession(session: OrchestrationPaymentSession | LegacyPaymentSession): Promise<void>;
+	setSession(session: LegacyPaymentSession): Promise<void>;
 	onExpires(callback: () => void): () => void;
 	getMop(mop: Partial<PurseHeadlessCheckoutPaymentItemBase>): PurseHeadlessCheckoutPaymentItem | null;
 	deleteAllTokens(): Promise<void>;
@@ -3244,7 +3288,7 @@ declare class PursePayment implements Payment {
 	});
 	get session(): PaymentSession;
 	get walletSession(): WalletSession | null;
-	setSession(session: OrchestrationPaymentSession | LegacyPaymentSession): Promise<void>;
+	setSession(session: LegacyPaymentSession): Promise<void>;
 	setWalletSession(session: OnePayWalletSession): Promise<void>;
 	onExpires(callback: () => void): () => void;
 	getMop(mop: Partial<PurseHeadlessCheckoutPaymentItem>): PurseHeadlessCheckoutPaymentItem | null;


### PR DESCRIPTION
## Summary

Consolidates #88 and #89 — both bot PRs were byte-for-byte identical (same generated output), so this replaces them with a single clean commit.

Targets **v0.9.0** (minor bump driven by `feat:` squash commit on merge).

### New API surface

**Wallet / tokens**
- `WalletAPI.setAsFavorite({ id })` — mark a token as favorite via the wallet API
- `PurseHeadlessCheckoutPrimaryToken.isFavorite` — reactive `Readable<boolean>`
- `PurseHeadlessCheckoutPrimaryToken.setAsFavorite()` — convenience wrapper
- `PurseHeadlessCheckoutToken.createdAt?` — ISO 8601 creation date for chronological sorting
- `IntegratedToken.created_at?` — raw wallet field

**Hosted fields**
- `PurseHeadlessCheckoutPrimaryMethod.supportsHostedFields` — whether method supports iframe card input
- `PurseHeadlessCheckoutPrimaryToken.supportsHostedFields` — same on token level
- `PurseHeadlessCheckoutGetPaymentElementOptions.partner` made optional (match by method alone)
- `PurseHeadlessCheckoutGetPaymentElementOptions.xPayButton?` — Apple Pay / Google Pay button config
- New error `METHOD_DOES_NOT_SUPPORT_HOSTED_FIELDS` (replaces silent warning)

**Dropin theme**
- `DropinTheme.title.color?` — title text color override
- `DropinTheme.xpay?` — Apple Pay (`buttonstyle`) + Google Pay (`buttonColor`) theme controls

**Session**
- `PaymentSession.source` narrowed to `LegacyPaymentSession`; `rawSource?` holds the `OrchestrationPaymentSession`
- `Payment.setSession` / `PursePayment.setSession` signature narrowed accordingly

**i18n**
- `common.sessionExpiredTitle`, `common.sessionExpiredBody`, `common.refreshPageToTryAgain` added across all locales

**Dropin hooks**
- `InitOptions.hooks.onRefreshSession` return type broadened to `PurseHeadlessCheckoutV1Params["paymentSession"] | string | void`

## Test plan

- [ ] CI build + lint + check-exports + unit tests pass on this PR
- [ ] After merge: `on-push-main` release workflow creates tag `v0.9.0`, bumps `package.json`, updates `CHANGELOG.md`